### PR TITLE
Use finite state automata to make splitting O(n^2) -> O(n)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,8 @@ exclude = [
 ]
 
 [dependencies]
+failure = "0.1"
+fst = "0.3"
+
+[dev-dependencies]
+quickcheck = "0.9"

--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -1,0 +1,140 @@
+use std::borrow::Cow;
+
+use fst::Automaton;
+
+pub enum PrefixAutomatonState {
+    Sink,
+    State(usize),
+}
+
+/// An automaton that matches every prefix of a string. For
+/// example, an automaton that matches *"hello"* will match:
+/// *""*, *"h"*, *"he"*, *"hel"*, *"hell"*, *"hello"*.
+///
+/// Only prefixes consisting of complete code points are
+/// recognized. For example, for the string *"ë"*, *[]*
+/// and *[0xc3, 0xab]* are accepted, whereas *[0xc3]* is
+/// not.
+pub struct PrefixAutomaton<'a>(Cow<'a, str>);
+
+impl<'a> Automaton for PrefixAutomaton<'a> {
+    type State = PrefixAutomatonState;
+
+    fn start(&self) -> Self::State {
+        PrefixAutomatonState::State(0)
+    }
+
+    fn is_match(&self, state: &Self::State) -> bool {
+        match *state {
+            PrefixAutomatonState::Sink => false,
+            PrefixAutomatonState::State(idx) => self.0.is_char_boundary(idx),
+        }
+    }
+
+    fn accept(&self, state: &Self::State, byte: u8) -> Self::State {
+        match *state {
+            PrefixAutomatonState::Sink => PrefixAutomatonState::Sink,
+            PrefixAutomatonState::State(idx) => {
+                if idx == self.0.len() {
+                    // Recognizing characters beyond the end of the string
+                    // leads to the sink state.
+                    PrefixAutomatonState::Sink
+                } else if self.0.as_bytes()[idx] == byte {
+                    // Move to the next state if the byte is recognized.
+                    PrefixAutomatonState::State(idx + 1)
+                } else {
+                    // Otherwise, the byte is not recognized and we move
+                    // to the sink state.
+                    PrefixAutomatonState::Sink
+                }
+            }
+        }
+    }
+}
+
+impl From<String> for PrefixAutomaton<'static> {
+    fn from(s: String) -> Self {
+        PrefixAutomaton(Cow::Owned(s))
+    }
+}
+
+impl<'a> From<&'a str> for PrefixAutomaton<'a> {
+    fn from(s: &'a str) -> Self {
+        PrefixAutomaton(Cow::Borrowed(s))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fst::Automaton;
+    use quickcheck::quickcheck;
+
+    use super::PrefixAutomaton;
+
+    fn automaton_match<A>(automaton: A, data: &[u8]) -> bool
+    where
+        A: Automaton,
+    {
+        let mut state = automaton.start();
+
+        for byte in data {
+            state = automaton.accept(&state, *byte);
+        }
+
+        automaton.is_match(&state)
+    }
+
+    /// Check that the automaton only matches on codepoint boundaries.
+    #[test]
+    fn do_not_match_incomplete_prefix_test() {
+        // UTF-8 encoding: [0xc3, 0xa4, 0xc3, 0xab]
+        let s = "äë";
+        let s_bytes = s.as_bytes();
+
+        let automaton = PrefixAutomaton::from(s);
+
+        assert!(automaton_match(&automaton, &s_bytes[..0]));
+        assert!(!automaton_match(&automaton, &s_bytes[..1]));
+        assert!(automaton_match(&automaton, &s_bytes[..2]));
+        assert!(!automaton_match(&automaton, &s_bytes[..3]));
+        assert!(automaton_match(&automaton, &s_bytes[..4]));
+    }
+
+    quickcheck! {
+        /// Check that all prefixes of a string are matched by its
+        /// prefix automaton.
+        fn prefix_matches_prop(s: String) -> bool {
+            let automaton = PrefixAutomaton::from(s.as_str());
+            let chars: Vec<_> = s.chars().collect();
+
+            for idx in 0..(chars.len() + 1) {
+                let prefix = &chars[..idx];
+                if !automaton_match(&automaton, prefix.iter().cloned().collect::<String>().as_bytes()) {
+                    return false;
+                }
+            }
+
+            true
+        }
+    }
+
+    quickcheck! {
+        /// Check prefixes on arbitrary strings.
+        fn random_string_prefix_matches_prop(s1: String, s2: String) -> bool {
+            let automaton = PrefixAutomaton::from(s1.as_str());
+
+            let chars1: Vec<_> = s1.chars().collect();
+            let chars2: Vec<_> = s2.chars().collect();
+
+            for idx in 0..(chars2.len() + 1) {
+                let prefix = &chars2[..idx];
+
+                if !automaton_match(&automaton, prefix.iter().cloned().collect::<String>().as_bytes()) && chars1.starts_with(prefix) {
+                    return false;
+                }
+            }
+
+            true
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,41 @@
-use std::collections::HashSet;
+use std::collections::BTreeSet;
+use std::convert::TryFrom;
+use std::io::{self, BufRead, Lines};
+
+use failure::Fail;
+use fst::{self, IntoStreamer, Set, SetBuilder, Streamer};
+
+mod automaton;
+use automaton::PrefixAutomaton;
+
+/// Errors that can occur while reading word pieces.
+#[derive(Debug, Fail)]
+pub enum WordPiecesError {
+    /// Finite state automaton error.
+    #[fail(display = "Finite state automaton error: {}", _0)]
+    FstError(fst::Error),
+
+    /// IO error.
+    #[fail(display = "IO error: {}", _0)]
+    IOError(io::Error),
+}
+
+impl From<io::Error> for WordPiecesError {
+    fn from(error: io::Error) -> Self {
+        WordPiecesError::IOError(error)
+    }
+}
+
+impl From<fst::Error> for WordPiecesError {
+    fn from(error: fst::Error) -> Self {
+        WordPiecesError::FstError(error)
+    }
+}
 
 /// A set of word pieces.
 pub struct WordPieces {
-    prefixes: HashSet<String>,
-    suffixes: HashSet<String>,
+    prefixes: Set,
+    suffixes: Set,
 }
 
 impl WordPieces {
@@ -11,75 +43,151 @@ impl WordPieces {
     ///
     /// The arguments are the prefix and suffix set. The suffix set
     /// should not have suffix markers (`##`).
-    pub fn new(prefixes: HashSet<String>, suffixes: HashSet<String>) -> Self {
+    pub fn new(prefixes: Set, suffixes: Set) -> Self {
         WordPieces { prefixes, suffixes }
     }
 
+    fn longest_prefix_len(affix_set: &Set, word: &str) -> usize {
+        let mut stream = affix_set.search(PrefixAutomaton::from(word)).into_stream();
+
+        let mut longest_len = match stream.next() {
+            Some(prefix) => prefix.len(),
+            None => return 0,
+        };
+
+        while let Some(prefix) = stream.next() {
+            if prefix.len() > longest_len {
+                longest_len = prefix.len()
+            }
+        }
+
+        longest_len
+    }
+
     /// Split a string into word pieces.
-    pub fn split(&self, word: &str) -> Result<Vec<String>, Vec<String>> {
-        // Get character offsets into `word`. Add the length of the
-        // word, for the upper bound of the string.
-        let mut char_indices: Vec<usize> = word.char_indices().map(|(idx, _)| idx).collect();
-        char_indices.push(word.len());
-
+    pub fn split(&self, mut word: &str) -> Result<Vec<String>, Vec<String>> {
         let mut pieces = Vec::new();
-        let mut begin = 0;
-        while begin < (char_indices.len() - 1) {
-            let mut end = char_indices.len() - 1;
 
-            while begin < end {
-                let candidate_piece = &word[char_indices[begin]..char_indices[end]];
+        // Find the word's prefix
+        let prefix_len = Self::longest_prefix_len(&self.prefixes, word);
+        if prefix_len == 0 {
+            return Err(pieces);
+        }
+        pieces.push(word[..prefix_len].to_string());
+        word = &word[prefix_len..];
 
-                if begin == 0 {
-                    // Prefix
-                    if self.prefixes.contains(candidate_piece) {
-                        pieces.push(candidate_piece.to_owned());
-                        break;
-                    }
-                } else {
-                    // Suffix
-                    if self.suffixes.contains(candidate_piece) {
-                        pieces.push(format!("##{}", candidate_piece.to_owned()));
-                        break;
-                    }
-                }
-
-                end -= 1;
-            }
-
-            if begin == end {
-                // No valid prefix could be found, return partial results.
+        // Find the word's suffixes.
+        while !word.is_empty() {
+            let prefix_len = Self::longest_prefix_len(&self.suffixes, word);
+            if prefix_len == 0 {
                 return Err(pieces);
-            } else {
-                begin = end;
             }
+
+            pieces.push(format!("##{}", word[..prefix_len].to_string()));
+            word = &word[prefix_len..];
         }
 
         Ok(pieces)
     }
 }
 
+impl<R> TryFrom<Lines<R>> for WordPieces
+where
+    R: BufRead,
+{
+    type Error = WordPiecesError;
+
+    fn try_from(lines: Lines<R>) -> Result<Self, Self::Error> {
+        let mut prefixes = BTreeSet::new();
+        let mut suffixes = BTreeSet::new();
+
+        for line in lines {
+            let line = line?;
+
+            if line.starts_with("##") {
+                suffixes.insert(line[2..].to_string());
+            } else {
+                prefixes.insert(line);
+            }
+        }
+
+        let mut prefix_set = SetBuilder::memory();
+        prefix_set.extend_iter(prefixes)?;
+
+        let mut suffix_set = SetBuilder::memory();
+        suffix_set.extend_iter(suffixes)?;
+
+        Ok(WordPieces {
+            prefixes: Set::from_bytes(prefix_set.into_inner()?)?,
+            suffixes: Set::from_bytes(suffix_set.into_inner()?)?,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
+    use std::collections::BTreeSet;
+    use std::convert::TryFrom;
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
     use std::iter::FromIterator;
+
+    use fst::{Set, SetBuilder};
 
     use super::WordPieces;
 
+    fn affixes_to_set(affixes: &[&str]) -> Set {
+        let affixes = BTreeSet::from_iter(affixes);
+        let mut builder = SetBuilder::memory();
+        builder.extend_iter(affixes).unwrap();
+        Set::from_bytes(builder.into_inner().unwrap()).unwrap()
+    }
+
     fn example_word_pieces() -> WordPieces {
         WordPieces {
-            prefixes: HashSet::from_iter(
-                (&["voor".to_string(), "coördina".to_string()])
-                    .iter()
-                    .map(Clone::clone),
-            ),
-            suffixes: HashSet::from_iter((&["tie".to_string()]).iter().map(Clone::clone)),
+            prefixes: affixes_to_set(&["voor", "coördina"]),
+            suffixes: affixes_to_set(&["tie", "kom", "en"]),
         }
     }
 
     #[test]
     fn test_word_pieces() {
         let word_pieces = example_word_pieces();
+
+        assert_eq!(word_pieces.split("voor"), Ok(vec!["voor".to_string()]));
+        assert_eq!(word_pieces.split("unknown"), Err(Vec::<String>::new()));
+        assert_eq!(word_pieces.split("voorman"), Err(vec!["voor".to_string()]));
+        assert_eq!(
+            word_pieces.split("coördinatie"),
+            Ok(vec!["coördina".to_string(), "##tie".to_string()])
+        );
+        assert_eq!(
+            word_pieces.split("voorkomen"),
+            Ok(vec![
+                "voor".to_string(),
+                "##kom".to_string(),
+                "##en".to_string()
+            ])
+        );
+    }
+
+    #[test]
+    fn longest_prefix_used() {
+        let word_pieces = WordPieces {
+            prefixes: affixes_to_set(&["foo", "fo"]),
+            suffixes: affixes_to_set(&["o", "bar", "b", "a", "r"]),
+        };
+
+        assert_eq!(
+            word_pieces.split("foobar"),
+            Ok(vec!["foo".to_string(), "##bar".to_string()])
+        );
+    }
+
+    #[test]
+    fn test_word_pieces_file() {
+        let f = File::open("testdata/test.pieces").unwrap();
+        let word_pieces = WordPieces::try_from(BufReader::new(f).lines()).unwrap();
 
         assert_eq!(word_pieces.split("voor"), Ok(vec!["voor".to_string()]));
         assert_eq!(word_pieces.split("unknown"), Err(Vec::<String>::new()));

--- a/testdata/test.pieces
+++ b/testdata/test.pieces
@@ -1,0 +1,3 @@
+voor
+##tie
+coördina


### PR DESCRIPTION
The word piece splitting functionality was quadratic time. This change
makes the splitting linear time by using finite state automata.

The prefix and suffixes set are stored in dictionary automata. A new
type, `PrefixAutomaton` is added. A prefix automaton matches every
prefix in a string. E.g. for the string "Rust", it matches:

```
[empty prefix]
R
Ru
Rus
Rust
```

By computing the intersection language of a dictionary automaton and a
prefix automaton, we can find the matching prefixes in the automaton
in linear time. We then take the longest matching prefix as a word
piece.

While at it, also implement `TryFrom` to construct the finite state
dictionaries from a file.