### PR TITLE
PrefixAutomaton: implement can_match

### DIFF
--- a/src/automaton.rs
+++ b/src/automaton.rs
@@ -24,6 +24,13 @@ impl<'a> Automaton for PrefixAutomaton<'a> {
         PrefixAutomatonState::State(0)
     }
 
+    fn can_match(&self, state: &Self::State) -> bool {
+        match *state {
+            PrefixAutomatonState::Sink => false,
+            PrefixAutomatonState::State(_) => true,
+        }
+    }
+
     fn is_match(&self, state: &Self::State) -> bool {
         match *state {
             PrefixAutomatonState::Sink => false,


### PR DESCRIPTION
This makes prefix searches orders of magnitude faster by ensuring that
the search ends in a sink state.