### PR TITLE
Update to fst 0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ exclude = [
 ]
 
 [dependencies]
-fst = "0.3"
+fst = "0.4"
 thiserror = "1"
 
 [dev-dependencies]


### PR DESCRIPTION
fst 0.4 adds a generic parameter to `Map`, so that it works both with
anything that can be represented as a slice reference (e.g. `Vec<u8>`
and `&[u8]`). The `WordPieces` expose this generic type parameter. The
reasoning is that word piece vocabularies are small enough to always
store a `Vec<u8>` and this keeps the types simpler (`WordPieces`
opposed to `WordPieces<D: AsRef<[u8]>>`) for downstream users.

If it turns out to be necessary, we could expose this type parameter
before branching version 1 of this crate.